### PR TITLE
Fix unit tests in symja parser, getVariables ordering

### DIFF
--- a/symja-parser/src/test/java/org/matheclipse/commons/parser/test/eval/EvalDfpRelaxedTestCase.java
+++ b/symja-parser/src/test/java/org/matheclipse/commons/parser/test/eval/EvalDfpRelaxedTestCase.java
@@ -160,11 +160,10 @@ public class EvalDfpRelaxedTestCase extends TestCase {
 			DfpEvaluator engine = new DfpEvaluator(50, true);
 			HashSet<String> result = new HashSet<String>();
 			engine.getVariables("a+2*b+$c", result);
-			ArrayList<String> list = new ArrayList<String>();
-			for (String string : result) {
-				list.add(string);
-			}
-			Assert.assertEquals(list.toString(), "[a, b, $c]");
+			Assert.assertEquals(result.size(), 3);
+			Assert.assertTrue(result.contains("a"));
+			Assert.assertTrue(result.contains("b"));
+			Assert.assertTrue(result.contains("$c"));
 		} catch (RuntimeException e) {
 			e.printStackTrace();
 			Assert.assertEquals("", e.getMessage());

--- a/symja-parser/src/test/java/org/matheclipse/commons/parser/test/eval/EvalDoubleRelaxedTestCase.java
+++ b/symja-parser/src/test/java/org/matheclipse/commons/parser/test/eval/EvalDoubleRelaxedTestCase.java
@@ -163,11 +163,10 @@ public class EvalDoubleRelaxedTestCase extends TestCase {
 			DoubleEvaluator engine = new DoubleEvaluator(true);
 			HashSet<String> result = new HashSet<String>();
 			engine.getVariables("a+2*b+$c", result);
-			ArrayList<String> list = new ArrayList<String>();
-			for (String string : result) {
-				list.add(string);
-			}
-			Assert.assertEquals(list.toString(), "[a, b, $c]");
+			Assert.assertEquals(result.size(), 3);
+			Assert.assertTrue(result.contains("a"));
+			Assert.assertTrue(result.contains("b"));
+			Assert.assertTrue(result.contains("$c"));
 		} catch (RuntimeException e) {
 			e.printStackTrace();
 			Assert.assertEquals("", e.getMessage());

--- a/symja-parser/src/test/java/org/matheclipse/commons/parser/test/eval/EvalDoubleTestCase.java
+++ b/symja-parser/src/test/java/org/matheclipse/commons/parser/test/eval/EvalDoubleTestCase.java
@@ -163,11 +163,10 @@ public class EvalDoubleTestCase extends TestCase {
 		try {
 			HashSet<String> result = new HashSet<String>();
 			DoubleEvaluator.getVariables("a+2*b+$c", result);
-			ArrayList<String> list = new ArrayList<String>();
-			for (String string : result) {
-				list.add(string);
-			}
-			Assert.assertEquals(list.toString(), "[a, b, $c]");
+			Assert.assertEquals(result.size(), 3);
+			Assert.assertTrue(result.contains("a"));
+			Assert.assertTrue(result.contains("b"));
+			Assert.assertTrue(result.contains("$c"));
 		} catch (RuntimeException e) {
 			e.printStackTrace();
 			Assert.assertEquals("", e.getMessage());


### PR DESCRIPTION
This patch fixes the unit test failure due to the arbitrary order in which
the variable names are returned from the getVariables method.

Change-Id: I9516e5c12cca502d583a75e328c04e1670d9b390
Signed-off-by: Ben Tucker <benjamint@bsquare.com>